### PR TITLE
fix(use-click-outside): prevent adding unnecessary event listeners 

### DIFF
--- a/src/hooks/use-click-outside.ts
+++ b/src/hooks/use-click-outside.ts
@@ -7,9 +7,14 @@ import { useEffect } from 'react';
 const useClickOutside = <T extends HTMLElement = HTMLElement>(
   ref: RefObject<T> | RefObject<T>[],
   handler: (event?: MouseEvent) => void,
-  ignoreCondition?: boolean,
+  hasListeners?: boolean,
 ) => {
   useEffect(() => {
+    // Prevent adding unnecessary event listeners.
+    if (!hasListeners) {
+      return;
+    }
+
     const listener = (event: MouseEvent) => {
       const refs = Array.isArray(ref) ? ref : [ref];
 
@@ -21,7 +26,7 @@ const useClickOutside = <T extends HTMLElement = HTMLElement>(
         }
       }
 
-      !ignoreCondition && handler(event); // Call the handler only if the click is outside the element passed.
+      handler(event);
     };
 
     document.addEventListener('mousedown', listener);
@@ -31,7 +36,7 @@ const useClickOutside = <T extends HTMLElement = HTMLElement>(
       document.removeEventListener('mousedown', listener);
       document.removeEventListener('touchstart', listener);
     };
-  }, [ref, handler, ignoreCondition]); // Reload only if ref or handler changes
+  }, [ref, handler, hasListeners]); // Reload only if ref or handler changes
 };
 
 export default useClickOutside;


### PR DESCRIPTION
**The reason:**

Usually we use this hook (useClickOutside) to close something (like a modal, select, dropdown, etc.), and when the components are closed, this hook still adds listeners (this is not normal).
My situation: I had 5 components that included this hook, and 5 components added 5 mousedown and 5 touchstart event listeners.

**Solution:**
Prevent adding event listeners when components are closed.

![Screenshot_5](https://user-images.githubusercontent.com/108662085/225396380-3c036e83-54b8-4bc1-a009-cd42fa46ce62.png)
